### PR TITLE
Remove the adaptation display map option

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "riskwise",
-  "version": "0.6.4",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "riskwise",
-      "version": "0.6.4",
+      "version": "1.0.0",
       "dependencies": {
         "@emotion/react": "^11.11.1",
         "@emotion/styled": "^11.11.0",
@@ -7305,6 +7305,20 @@
       "dev": true,
       "engines": {
         "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/config-file-ts/node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/confusing-browser-globals": {
@@ -18657,15 +18671,17 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
-      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=4.2.0"
       }
     },
     "node_modules/unbox-primitive": {

--- a/src/components/controls/MainViewControls.js
+++ b/src/components/controls/MainViewControls.js
@@ -7,14 +7,17 @@ import BarChartIcon from "@mui/icons-material/BarChart";
 
 import useStore from "../../store";
 
-const controls = [
+const allControls = [
   { id: "display_map", icon: <MapIcon /> },
   { id: "display_chart", icon: <BarChartIcon /> },
 ];
 
 const MainViewControls = () => {
-  const { activeViewControl, setActiveViewControl } = useStore();
+  const { activeViewControl, setActiveViewControl, selectedSubTab } = useStore();
   const { t } = useTranslation();
+
+  const controls =
+    selectedSubTab === 1 ? allControls.filter((c) => c.id !== "display_map") : allControls;
 
   const handleSelect = (control) => {
     setActiveViewControl(control);
@@ -23,6 +26,7 @@ const MainViewControls = () => {
   return (
     <Card
       sx={{
+        // maxWidth: controls.length === 1 ? "50%" : "100%",
         maxWidth: "100%",
         margin: "auto",
         bgcolor: "#FFCCCC",

--- a/src/components/main/MainSubTabs.js
+++ b/src/components/main/MainSubTabs.js
@@ -33,6 +33,8 @@ const MainSubTabs = () => {
 
   const handleSubTabChange = (event, newValue) => {
     setSelectedSubTab(newValue);
+    // Set the active vew to display_chart if Economic & Non-Economic tab is selected.
+    // The display_map is not currently available for this tab.
     if (newValue === 1) {
       setActiveViewControl("display_chart");
     }

--- a/src/components/main/MainSubTabs.js
+++ b/src/components/main/MainSubTabs.js
@@ -7,7 +7,13 @@ import useStore from "../../store";
 import { useMapTools } from "../../utils/mapTools";
 
 const MainSubTabs = () => {
-  const { activeViewControl, selectedSubTab, selectedTab, setSelectedSubTab } = useStore();
+  const {
+    activeViewControl,
+    selectedSubTab,
+    selectedTab,
+    setSelectedSubTab,
+    setActiveViewControl,
+  } = useStore();
   const { handleSaveImage, handleSaveMap, handleAddToOutput } = useMapTools();
   const { t } = useTranslation();
 
@@ -27,6 +33,9 @@ const MainSubTabs = () => {
 
   const handleSubTabChange = (event, newValue) => {
     setSelectedSubTab(newValue);
+    if (newValue === 1) {
+      setActiveViewControl("display_chart");
+    }
   };
 
   const handleButtonClick = (index) => {


### PR DESCRIPTION
Remove the Display Map option on the Economic & Non-Economic tab and Adaptation subtab section.
Functionality remains in case the map generation is added later on.

- Remove adaptation display map button.
- Display chart view control is automatically selected after selecting the Adaptation subtab.

Resolves #6 